### PR TITLE
Correct filename on download

### DIFF
--- a/main.py
+++ b/main.py
@@ -106,6 +106,7 @@ def parse_upload():
     return jsonify(data)
 
 @app.route('/download/<ts>', methods=['GET'])
+# If requesting to redownload a previous powerpoint, browser caches previous download and pull from cache instead of server if cache is present.
 def download_audit(ts):
     dirs = os.listdir(UPLOAD_DIR)
     # FIXME: This has not been getting the correct ppts
@@ -122,10 +123,14 @@ def download_audit(ts):
     abs_path_proj_dir = app.root_path + '/uploads/' + requested_audit
     files = os.listdir(abs_path_proj_dir)
     project_name = files[0]
+    
+    project_name_split = project_name.split(".")
+    final_project_name = project_name_split[0]
+
     # Name differs when first sending out file vs when pulling from URL query.
     # This probably won't be an issue moving forward if we request downloads using ID's or via other methods.
     ppt_path = os.path.join(UPLOAD_DIR, abs_path_proj_dir + f'/{project_name}')
-    return send_file(ppt_path, mimetype=None, as_attachment=True, attachment_filename= requested_audit + "_" + project_name)
+    return send_file(ppt_path, mimetype=None, as_attachment=True, attachment_filename= final_project_name + "-" + requested_audit + ".pptx")
 
 
 

--- a/main.py
+++ b/main.py
@@ -88,14 +88,8 @@ def parse_upload():
         file.save(os.path.join(project_dir, filename))
 
     # Create project name
-    proj_files = os.listdir(project_dir)
-    segments = proj_files[0].split('_')
-    print("segments:", segments)
-
     # Get project name from front-end and sanitize
     project_name = request.form.get("project-name")
-    # project_name = segments[0].split('.')[0]
-    print("Project name:", project_name)
 
     # Let TADAA do it's thing
     root_path = app.root_path


### PR DESCRIPTION
When requesting download via /download/timestamp route, filename reflect that of initial naming convention when running "Download PPT"